### PR TITLE
Add config for `DISABLE_ALL_LIBRARY_WARNINGS`

### DIFF
--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -16,6 +16,7 @@ AUTO_LOAD = ["psram"]
 CONF_BACKLIGHT = "backlight"
 CONF_LOAD_FONTS = "load_fonts"
 CONF_LOAD_SMOOTH_FONTS = "load_smooth_fonts"
+CONF_DISABLE_ALL_LIBRARY_WARNINGS = "disable_all_library_warnings"
 
 TDISPLAYS3 = tdisplays3_ns.class_(
     "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
@@ -30,6 +31,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_BACKLIGHT, default=False): cv.boolean,
             cv.Optional(CONF_LOAD_FONTS, default=False): cv.boolean,
             cv.Optional(CONF_LOAD_SMOOTH_FONTS, default=False): cv.boolean,
+            cv.Optional(CONF_DISABLE_ALL_LIBRARY_WARNINGS, default=False): cv.boolean,
         }
     ).extend(cv.polling_component_schema("5s")),
 )
@@ -73,6 +75,9 @@ async def to_code(config):
         cg.add_build_flag("-DSMOOTH_FONT")
         cg.add_library("FS", None)
         cg.add_library("SPIFFS", None)
+    
+    if config[CONF_DISABLE_ALL_LIBRARY_WARNINGS]:
+        cg.add_build_flag("-DDISABLE_ALL_LIBRARY_WARNINGS")
     
     # TODO:
     # PIN_POWER_ON 15

--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -21,7 +21,7 @@ DEPENDENCIES = ["esp32"]
 CONF_BACKLIGHT = "backlight"
 CONF_LOAD_FONTS = "load_fonts"
 CONF_LOAD_SMOOTH_FONTS = "load_smooth_fonts"
-CONF_DISABLE_ALL_LIBRARY_WARNINGS = "disable_all_library_warnings"
+CONF_ENABLE_LIBRARY_WARNINGS = "enable_library_warnings"
 
 TDISPLAYS3 = tdisplays3_ns.class_(
     "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
@@ -36,7 +36,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_BACKLIGHT, default=False): cv.boolean,
             cv.Optional(CONF_LOAD_FONTS, default=False): cv.boolean,
             cv.Optional(CONF_LOAD_SMOOTH_FONTS, default=False): cv.boolean,
-            cv.Optional(CONF_DISABLE_ALL_LIBRARY_WARNINGS, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_LIBRARY_WARNINGS, default=False): cv.boolean,
             cv.Optional(CONF_RESET_PIN, default=5): pins.gpio_output_pin_schema,
             cv.Optional(CONF_CS_PIN, default=6): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DC_PIN, default=7): pins.gpio_output_pin_schema,
@@ -84,10 +84,10 @@ async def to_code(config):
         cg.add_build_flag("-DSMOOTH_FONT")
         cg.add_library("FS", None)
         cg.add_library("SPIFFS", None)
-    
-    if config[CONF_DISABLE_ALL_LIBRARY_WARNINGS]:
+
+    if not config[CONF_ENABLE_LIBRARY_WARNINGS]:
         cg.add_build_flag("-DDISABLE_ALL_LIBRARY_WARNINGS")
-    
+
     # TODO:
     # PIN_POWER_ON 15
     # Bat_Volt  4


### PR DESCRIPTION
Allow setting of `DISABLE_ALL_LIBRARY_WARNINGS` build flag for TFT library.

This removes the expected warnings from build output like:
- `#warning >>>>------>> DMA is not supported in parallel mode`
- `#warning >>>>------>> TOUCH_CS pin not defined, TFT_eSPI touch functions will not be available!`

Example:

```yaml
display:
  - platform: tdisplays3
    enable_library_warnings: true|false
    lambda: |-
      ...
```