### PR TITLE
Fix crashloop in touchscreen devices

### DIFF
--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -104,6 +104,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await display.register_display(var, config)
+    cg.add(var.set_dimensions(config[CONF_WIDTH], config[CONF_HEIGHT]));
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/components/tdisplays3/t_display_s3.cpp
+++ b/components/tdisplays3/t_display_s3.cpp
@@ -30,9 +30,30 @@ void TDisplayS3::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->spr_->drawPixel(x, y, display::ColorUtil::color_to_565(color));
 }
 
+int TDisplayS3::get_width_internal() {
+  if (this->tft_) {
+    return this->tft_->getViewportWidth();
+  } else {
+    return this->width_;
+  }
+}
+
+int TDisplayS3::get_height_internal() {
+  if (this->tft_) {
+    return this->tft_->getViewportHeight();
+  } else {
+    return this->height_;
+  }
+}
+
 void TDisplayS3::update() {
   this->do_update_();
   this->spr_->pushSprite(0, 0);
+}
+
+void TDisplayS3::set_dimensions(uint16_t width, uint16_t height) {
+  this->width_ = width;
+  this->height_ = height;
 }
 
 }  // namespace tdisplays3

--- a/components/tdisplays3/t_display_s3.h
+++ b/components/tdisplays3/t_display_s3.h
@@ -15,16 +15,20 @@ class TDisplayS3 : public PollingComponent, public display::DisplayBuffer {
   void setup() override;
 
   void fill(Color color) override;
-  int get_width_internal() override { return this->tft_->getViewportWidth(); }
-  int get_height_internal() override { return this->tft_->getViewportHeight(); }
+  int get_width_internal() override;
+  int get_height_internal() override;
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
 
   void update() override;
 
+  void set_dimensions(uint16_t width, uint16_t height);
+
  private:
   TFT_eSPI *tft_{nullptr};
   TFT_eSprite *spr_{nullptr};
+  uint16_t width_{0};
+  uint16_t height_{0};
 };
 
 }  // namespace tdisplays3


### PR DESCRIPTION
The touchscreen component needs to access width and height before the setup method of the display is completed.
This was causing a nullptr access, and a crash.

Added some default values to be able to get width and height when the setup method has not been executed yet.

Fixes #32 