### PR TITLE
Fix compilation for esphome >= 2023.12.0

### DIFF
--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -101,7 +101,8 @@ async def to_code(config):
     cg.add_library("TFT_eSPI", None)
 
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
     await display.register_display(var, config)
     cg.add(var.set_dimensions(config[CONF_WIDTH], config[CONF_HEIGHT]));
 

--- a/components/tdisplays3/t_display_s3.h
+++ b/components/tdisplays3/t_display_s3.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/defines.h"
+#include "esphome/core/version.h"
 #include "TFT_eSPI.h"
 
 #include "esphome/components/display/display_buffer.h"
@@ -9,7 +10,11 @@
 namespace esphome {
 namespace tdisplays3 {
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class TDisplayS3 : public display::DisplayBuffer {
+#else
 class TDisplayS3 : public PollingComponent, public display::DisplayBuffer {
+#endif  // VERSION_CODE(2023, 12, 0)
  public:
   void dump_config() override;
   void setup() override;


### PR DESCRIPTION
In the last release of ESPHome, some small changes were done to the display component, to make subcomponents leaner. With those changes, compilation breaks if a display is trying to register as a component itself (this is now done automatically when registering the display).

Also, DisplayBuffer now automatically inherits from PollingComponent, so there is no need to explicitly inherit from that.

This is probably a breaking change if someone uses a lower version of esphome after this is merged.