### PR TITLE
Update touchscreen to ESPHome 2023.12.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
           extensions: 'h,cpp'
           style: file
           clangFormatVersion: 16
+      - name: "Replace branch reference"
+        run: sed -i "s#\(github://${{ github.repository }}\)\(@[^ ]*\)\?#\1@${{ github.head_ref }}#" ${{ matrix.devices }}.yaml
       - uses: esphome/build-action@v1
         with:
           yaml_file: ${{ matrix.devices }}.yaml

--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -24,9 +24,15 @@ CONF_LOAD_FONTS = "load_fonts"
 CONF_LOAD_SMOOTH_FONTS = "load_smooth_fonts"
 CONF_ENABLE_LIBRARY_WARNINGS = "enable_library_warnings"
 
-TDISPLAYS3 = tdisplays3_ns.class_(
-    "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
-)
+
+if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+    TDISPLAYS3 = tdisplays3_ns.class_(
+        "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
+    )
+else:
+    TDISPLAYS3 = tdisplays3_ns.class_(
+        "TDisplayS3", cg.PollingComponent, display.Display
+    )
 
 CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(

--- a/components/tdisplays3/touchscreen/t_display_s3_touchscreen.h
+++ b/components/tdisplays3/touchscreen/t_display_s3_touchscreen.h
@@ -3,10 +3,12 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/touchscreen/touchscreen.h"
 #include "esphome/core/component.h"
+#include "esphome/core/version.h"
 
 namespace esphome {
 namespace tdisplays3 {
 
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
 /**
  * Store interrupt related information.
  */
@@ -16,11 +18,18 @@ struct Store {
 
   static void gpio_intr(Store *store);
 };
+#endif  // VERSION_CODE(2023, 12, 0)
 
-class LilygoTDisplayS3Touchscreen : public touchscreen::Touchscreen, public Component, public i2c::I2CDevice {
+class LilygoTDisplayS3Touchscreen : public touchscreen::Touchscreen,
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
+                                    public Component,
+#endif  // VERSION_CODE(2023, 12, 0)
+                                    public i2c::I2CDevice {
  public:
   void setup() override;
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
   void loop() override;
+#endif  // VERSION_CODE(2023, 12, 0)
   void dump_config() override;
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
@@ -37,7 +46,11 @@ class LilygoTDisplayS3Touchscreen : public touchscreen::Touchscreen, public Comp
   int16_t x_offset_;
   int16_t y_offset_;
   uint16_t firmware_version_;
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
   Store store_;
+#else
+  void update_touches() override;
+#endif  // VERSION_CODE(2023, 12, 0)
 };
 
 }  // namespace tdisplays3

--- a/example-with-touch.yaml
+++ b/example-with-touch.yaml
@@ -41,12 +41,12 @@ time:
 
 binary_sensor:
   - platform: gpio
-    pin: 
+    pin:
       number: GPIO0
       inverted: true
     name: "Button 1"
   - platform: gpio
-    pin: 
+    pin:
       number: GPIO14
       inverted: true
     name: "Button 2"
@@ -93,19 +93,16 @@ touchscreen:
   - platform: tdisplays3
     interrupt_pin: 16
     address: 0x15
-    # The T-Display S3 has a round button below the screen.
-    # With the current rotation (270°), touching this button produces a
-    # negative coordinate (-40), which is cannot be used in ESPHome for a
-    # touch point.
-    # Adding an offset moves *all* points by that offset, allowing to use
-    # the button in this rotation as well.
-    # Rotation 180° would need an y offset instead; this is also supported.
-    x_offset: 40
     id: my_touchscreen
+    display: disp
+    transform:
+      swap_xy: true
+      mirror_y: true
     on_touch:
       - lambda: |-
+         auto touch_point = id(my_touchscreen).get_touches()[0];
          ESP_LOGI("tdisplays3-touch", "x:%d, y:%d",
-           id(my_touchscreen).x,
-           id(my_touchscreen).y
+           touch_point.x,
+           touch_point.y
          );
       # - switch.toggle: backlight


### PR DESCRIPTION
The touchscreen base component had some breaking changes that required adaptations.

Also the yaml configuration is slightly different, so updated the example-touch.yaml file as well

Fixes: #48 