### PR TITLE
Touchscreen needs the display to inherit from Display

### DIFF
--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -24,9 +24,15 @@ CONF_LOAD_FONTS = "load_fonts"
 CONF_LOAD_SMOOTH_FONTS = "load_smooth_fonts"
 CONF_ENABLE_LIBRARY_WARNINGS = "enable_library_warnings"
 
-TDISPLAYS3 = tdisplays3_ns.class_(
-    "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
-)
+if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+    TDISPLAYS3 = tdisplays3_ns.class_(
+        "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
+    )
+else:
+    TDISPLAYS3 = tdisplays3_ns.class_(
+        "TDisplayS3", cg.PollingComponent, display.Display
+    )
+
 
 CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(


### PR DESCRIPTION
Instead of inheriting form DisplayBuffer, the new touchscreen component (from 2023.12.0 onwards) needs a Display.

Splitting this from #50 to try and make CI happy