### PR TITLE
Try to automatically configure the touchscreen rotation

### DIFF
--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -24,9 +24,15 @@ CONF_LOAD_FONTS = "load_fonts"
 CONF_LOAD_SMOOTH_FONTS = "load_smooth_fonts"
 CONF_ENABLE_LIBRARY_WARNINGS = "enable_library_warnings"
 
-TDISPLAYS3 = tdisplays3_ns.class_(
-    "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
-)
+
+if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+    TDISPLAYS3 = tdisplays3_ns.class_(
+        "TDisplayS3", cg.PollingComponent, display.DisplayBuffer
+    )
+else:
+    TDISPLAYS3 = tdisplays3_ns.class_(
+        "TDisplayS3", cg.PollingComponent, display.Display
+    )
 
 CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(

--- a/components/tdisplays3/display.py
+++ b/components/tdisplays3/display.py
@@ -24,6 +24,10 @@ CONF_LOAD_FONTS = "load_fonts"
 CONF_LOAD_SMOOTH_FONTS = "load_smooth_fonts"
 CONF_ENABLE_LIBRARY_WARNINGS = "enable_library_warnings"
 
+CONF_TRANSFORM = "transform"
+CONF_SWAP_XY = "swap_xy"
+CONF_MIRROR_X = "mirror_x"
+CONF_MIRROR_Y = "mirror_y"
 
 if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
     TDISPLAYS3 = tdisplays3_ns.class_(
@@ -38,6 +42,13 @@ CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(TDISPLAYS3),
+            cv.Optional(CONF_TRANSFORM): cv.Schema(
+                {
+                    cv.Optional(CONF_SWAP_XY, default=False): cv.boolean,
+                    cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
+                    cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
+                }
+            ),
             cv.Optional(CONF_HEIGHT, default=320): cv.uint16_t,
             cv.Optional(CONF_WIDTH, default=170): cv.uint16_t,
             cv.Optional(CONF_BACKLIGHT, default=False): cv.boolean,

--- a/components/tdisplays3/touchscreen/__init__.py
+++ b/components/tdisplays3/touchscreen/__init__.py
@@ -1,12 +1,18 @@
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
+import esphome.final_validate as fv
 
 from esphome import pins
 from esphome.components import i2c, touchscreen
+from esphome.components.touchscreen import CONF_DISPLAY, CONF_TRANSFORM, CONF_SWAP_XY, CONF_MIRROR_X, CONF_MIRROR_Y
 from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_RESET_PIN
 from esphome.const import __version__ as ESPHOME_VERSION
 
 from .. import tdisplays3_ns
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["i2c"]
 
@@ -26,6 +32,53 @@ else:
 
 CONF_OFFSET_X = "x_offset"
 CONF_OFFSET_Y = "y_offset"
+CONF_ROTATION = "rotation"
+
+def inherit_transform(touchscreen_config):
+    """
+    If the display configuration has a 'transform' option and the touchscreen doesn't,
+    copy that configuration.
+    If the display configuration has a 'rotation' option and the touchscreen doesn't have a
+    'transform' option, translate the rotation to the needed transform configurations and add
+    it to the touchscreen configuration.
+    """
+
+    if CONF_TRANSFORM in touchscreen_config:
+        _LOGGER.debug("'transform' manually specified on the touchscreen. Do not inherit form display")
+        return touchscreen_config
+
+    fconf = fv.full_config.get()
+    display_path = fconf.get_path_for_id(touchscreen_config[CONF_DISPLAY])[:-1]
+    display_config = fconf.get_config_for_path(display_path)
+
+    if CONF_TRANSFORM in display_config:
+        transform = display_config[CONF_TRANSFORM]
+        _LOGGER.info("Copying transform from display %s: %s", display_config[CONF_ID], transform)
+        touchscreen_config[CONF_TRANSFORM] = transform
+    elif CONF_ROTATION in display_config:
+        rotation = display_config[CONF_ROTATION]
+        transform = {}
+        if rotation == 0:
+            transform[CONF_SWAP_XY] = False
+            transform[CONF_MIRROR_X] = False
+            transform[CONF_MIRROR_Y] = False
+        elif rotation == 90:
+            transform[CONF_SWAP_XY] = True
+            transform[CONF_MIRROR_X] = False
+            transform[CONF_MIRROR_Y] = False
+        elif rotation == 180:
+            transform[CONF_SWAP_XY] = False
+            transform[CONF_MIRROR_X] = True
+            transform[CONF_MIRROR_Y] = False
+        elif rotation == 270:
+            transform[CONF_SWAP_XY] = True
+            transform[CONF_MIRROR_X] = True
+            transform[CONF_MIRROR_Y] = False
+        _LOGGER.info("Translating rotation %d from display %s: %s", display_config[CONF_ROTATION], display_config[CONF_ID], transform)
+        touchscreen_config[CONF_TRANSFORM] = transform
+
+    return touchscreen_config
+
 
 CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
     cv.Schema(
@@ -41,6 +94,7 @@ CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
     .extend(i2c.i2c_device_schema(0x15))
 )
 
+FINAL_VALIDATE_SCHEMA = cv.All(inherit_transform)
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/components/tdisplays3/touchscreen/t_display_s3_touchscreen.h
+++ b/components/tdisplays3/touchscreen/t_display_s3_touchscreen.h
@@ -3,10 +3,12 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/touchscreen/touchscreen.h"
 #include "esphome/core/component.h"
+#include "esphome/core/version.h"
 
 namespace esphome {
 namespace tdisplays3 {
 
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
 /**
  * Store interrupt related information.
  */
@@ -16,11 +18,18 @@ struct Store {
 
   static void gpio_intr(Store *store);
 };
+#endif  // VERSION_CODE(2023, 12, 0)
 
-class LilygoTDisplayS3Touchscreen : public touchscreen::Touchscreen, public Component, public i2c::I2CDevice {
+class LilygoTDisplayS3Touchscreen : public touchscreen::Touchscreen,
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
+                                    public Component,
+#endif  // VERSION_CODE(2023, 12, 0)
+                                    public i2c::I2CDevice {
  public:
   void setup() override;
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
   void loop() override;
+#endif  // VERSION_CODE(2023, 12, 0)
   void dump_config() override;
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
@@ -37,7 +46,11 @@ class LilygoTDisplayS3Touchscreen : public touchscreen::Touchscreen, public Comp
   int16_t x_offset_;
   int16_t y_offset_;
   uint16_t firmware_version_;
+#if ESPHOME_VERSION_CODE < VERSION_CODE(2023, 12, 0)
   Store store_;
+#else
+  void update_touches() override;
+#endif  // VERSION_CODE(2023, 12, 0)
 };
 
 }  // namespace tdisplays3

--- a/example-with-touch.yaml
+++ b/example-with-touch.yaml
@@ -41,12 +41,12 @@ time:
 
 binary_sensor:
   - platform: gpio
-    pin: 
+    pin:
       number: GPIO0
       inverted: true
     name: "Button 1"
   - platform: gpio
-    pin: 
+    pin:
       number: GPIO14
       inverted: true
     name: "Button 2"
@@ -93,19 +93,16 @@ touchscreen:
   - platform: tdisplays3
     interrupt_pin: 16
     address: 0x15
-    # The T-Display S3 has a round button below the screen.
-    # With the current rotation (270°), touching this button produces a
-    # negative coordinate (-40), which is cannot be used in ESPHome for a
-    # touch point.
-    # Adding an offset moves *all* points by that offset, allowing to use
-    # the button in this rotation as well.
-    # Rotation 180° would need an y offset instead; this is also supported.
-    x_offset: 40
     id: my_touchscreen
+    display: disp
+    transform:
+      swap_xy: true
+      mirror_y: true
     on_touch:
       - lambda: |-
+         auto touch_point = id(my_touchscreen).get_touches()[0];
          ESP_LOGI("tdisplays3-touch", "x:%d, y:%d",
-           id(my_touchscreen).x,
-           id(my_touchscreen).y
+           touch_point.x,
+           touch_point.y
          );
       # - switch.toggle: backlight


### PR DESCRIPTION
Try to copy the rotation from the display, to avoid having to manually specify the transform options.

This is work in progress; not fully tested, and might not work for all rotations.
